### PR TITLE
Wording: Replace 'acknowledged' with 'wiped'

### DIFF
--- a/src/ControlTower/Government.php
+++ b/src/ControlTower/Government.php
@@ -39,6 +39,6 @@ class Government
 
         $this->debtRepository->ackAllDebts();
 
-        $this->messagePoster->postMessage('The amnesty has been redeemed. All debts have been acknowledged. 🎆');
+        $this->messagePoster->postMessage('The amnesty has been redeemed. All debts have been wiped. 🎆');
     }
 }

--- a/tests/Acceptance/AcceptenceTest.php
+++ b/tests/Acceptance/AcceptenceTest.php
@@ -157,7 +157,7 @@ class AcceptenceTest extends WebTestCase
         $mockHttpClient->setResponseFactory(function (string $method, string $url, array $options = []): MockResponse {
             $this->assertSame('POST', $method);
             $this->assertSame('https://slack.com/api/chat.postMessage', $url);
-            $this->assertSame('{"channel":"MY_CHANNEL_ID","text":"The amnesty has been redeemed. All debts have been acknowledged. \ud83c\udf86","blocks":[]}', $options['body']);
+            $this->assertSame('{"channel":"MY_CHANNEL_ID","text":"The amnesty has been redeemed. All debts have been wiped. \ud83c\udf86","blocks":[]}', $options['body']);
 
             return new MockResponse('{"ok": true}');
         });


### PR DESCRIPTION
Hello 👋🏽 

This tiny PR aims to, in my opinion, make the amnesty announcement sound better.

To "acknowledge" a debt means to accept it, and formally agree on it, in the case of the amnesty command, it is more a question of erasing every debts, to "wipe" them 😄 