### PR TITLE
Configure Dependabot and remove unused Node.js/Yarn tooling

### DIFF
--- a/.castor/qa.php
+++ b/.castor/qa.php
@@ -91,22 +91,6 @@ function securityAudit(): int
         }
     }
 
-    if (is_file("{$basePath}/yarn.lock")) {
-        io()->text('Running Yarn audit...');
-
-        $exitCode = docker_exit_code(['yarn', 'audit']);
-
-        if (0 !== $exitCode) {
-            return $exitCode;
-        }
-    }
-
-    if (is_file("{$basePath}/package-lock.json")) {
-        io()->text('Running NPM audit...');
-
-        return docker_exit_code(['npm', 'audit']);
-    }
-
     return 0;
 }
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,12 +13,30 @@ updates:
           default-days: 7
 
     - package-ecosystem: 'composer'
-      directory: '/'
+      directories:
+          - '/'
+          - '/tools/php-cs-fixer'
+          - '/tools/phpstan'
+          - '/tools/twig-cs-fixer'
       target-branch: 'main'
       schedule:
           interval: 'monthly'
       groups:
           composer:
+              patterns:
+                  - '*'
+      cooldown:
+          default-days: 7
+
+    - package-ecosystem: 'docker'
+      directories:
+          - '/infrastructure/docker/services/php'
+          - '/infrastructure/docker/services/router'
+      target-branch: 'main'
+      schedule:
+          interval: 'monthly'
+      groups:
+          docker:
               patterns:
                   - '*'
       cooldown:

--- a/castor.php
+++ b/castor.php
@@ -35,7 +35,7 @@ function create_default_variables(): array
     ];
 }
 
-#[AsTask(description: 'Builds and starts the infrastructure, then install the application (composer, yarn, ...)')]
+#[AsTask(description: 'Builds and starts the infrastructure, then install the application (composer, ...)')]
 function start(): void
 {
     io()->title('Starting the stack');
@@ -53,7 +53,7 @@ function start(): void
     about();
 }
 
-#[AsTask(description: 'Installs the application (composer, yarn, ...)', namespace: 'app', aliases: ['install'])]
+#[AsTask(description: 'Installs the application (composer, ...)', namespace: 'app', aliases: ['install'])]
 function install(): void
 {
     io()->title('Installing the application');
@@ -63,18 +63,6 @@ function install(): void
     if (is_file("{$basePath}/composer.json")) {
         io()->section('Installing PHP dependencies');
         docker_compose_run(['composer', 'install', '-n', '--prefer-dist', '--optimize-autoloader']);
-    }
-    if (is_file("{$basePath}/yarn.lock")) {
-        io()->section('Installing Node.js dependencies');
-        docker_compose_run(['yarn', 'install', '--immutable']);
-    } elseif (is_file("{$basePath}/package.json")) {
-        io()->section('Installing Node.js dependencies');
-
-        if (is_file("{$basePath}/package-lock.json")) {
-            docker_compose_run(['npm', 'ci']);
-        } else {
-            docker_compose_run(['npm', 'install']);
-        }
     }
     if (is_file("{$basePath}/importmap.php")) {
         io()->section('Installing importmap');

--- a/infrastructure/docker/docker-compose.yml
+++ b/infrastructure/docker/docker-compose.yml
@@ -17,8 +17,6 @@ x-templates:
 
 volumes:
     postgres-data: {}
-    # # Needed if $XDG_ env vars have been overridden
-    # builder-yarn-data: {}
 
 services:
     postgres:
@@ -85,10 +83,6 @@ services:
         volumes:
             - "../..:/var/www:cached"
             - "../../.home:/home/app:cached"
-            # Needed when $XDG_ env vars have overridden, to persist the yarn
-            # cache between builder and watcher, adapt according to the location
-            # of $XDG_DATA_HOME
-            # - "builder-yarn-data:/data/yarn"
         depends_on:
             - postgres
         profiles:

--- a/infrastructure/docker/services/php/Dockerfile
+++ b/infrastructure/docker/services/php/Dockerfile
@@ -83,24 +83,16 @@ FROM php-base AS builder
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG NODEJS_VERSION=24.x
-RUN curl -s https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg \
-    && echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODEJS_VERSION} nodistro main" > /etc/apt/sources.list.d/nodesource.list
-
 # Default toys
-ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         "git" \
         "make" \
-        "nodejs" \
         "php${PHP_VERSION}-dev" \
         "sudo" \
         "unzip" \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/* \
-    && corepack enable \
-    && yarn set version stable
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 # Install a fake sudo command
 # This is commented out by default because it exposes a security risk if you use this image in production, but it may be useful for development


### PR DESCRIPTION
## Summary
- Factorize Dependabot composer config using `directories` to also cover `tools/php-cs-fixer`, `tools/phpstan`, `tools/twig-cs-fixer`. Both ecosystems (github-actions, composer) run monthly with a 7-day cooldown.
- Remove Node.js/Yarn/corepack setup from the builder Docker image, docker-compose comments, and castor tasks (`install`, `securityAudit`), since this stack doesn't use a JS toolchain.